### PR TITLE
filter domain and ip from log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "qp-trie",
+ "regex",
  "reqwest",
  "rustc_version",
  "rustls",
@@ -1188,12 +1189,13 @@ dependencies = [
 
 [[package]]
 name = "my-env-logger-style"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14c19e713a80f4e9f2d13d511b6279f71fe915dd56449c5249ec6f040ce2a67"
+checksum = "fdc6d27d9682590c539672997bbf3603a9fea56c063f1da99e883e57d74356f2"
 dependencies = [
  "env_logger",
  "log",
+ "once_cell",
  "rustc_version",
 ]
 
@@ -1597,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1609,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1620,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bit-vec = "0.6.3"
 chumsky = "0.9.2"
 directories = "5.0.0"
 log = "0.4.17"
-my-env-logger-style = "0.1.0"
+my-env-logger-style = { version = "0.1.1", features = ["custom-arg-formatter"] }
 nohash-hasher = "0.2.0"
 num-format = "0.4.4"
 once_cell = { version = "1.17.1", features = ["parking_lot"] }
@@ -44,6 +44,7 @@ trust-dns-proto = {  package = "hickory-proto", version = "0.24", default-featur
 trust-dns-server = { package = "hickory-server", version = "0.24", default-features = false,  features = ["dnssec-ring", "dns-over-h3" ,"dns-over-rustls", "dns-over-https-rustls", "dns-over-quic"] }
 hickory-resolver = { version = "0.24.0", default-features = false, features = ["webpki-roots"] }
 url = { version = "2.3.1", features = ["serde"] }
+regex = "1.10.2"
 
 [dev-dependencies]
 indoc = "2.0.1"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -10,7 +10,7 @@ static REGEX: Lazy<Regex> = Lazy::new(|| {
 	// https://ihateregex.io/expr/ipv6/
 	let regex_ipv6 = r"(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
 	// emoji: https://ihateregex.io/expr/emoji/
-	let regex_domain = r"(([\w\-]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))+\.){2,}";
+	let regex_domain = r"(([\w\-\p{Math}\p{Emoji}\p{Emoji_Component}])+\.){2,}";
 	Regex::new(&format! {"{regex_ipv4}|{regex_ipv6}|{regex_domain}"}).unwrap()
 });
 
@@ -45,5 +45,18 @@ mod tests {
 	#[test]
 	fn regex() {
 		Lazy::force(&REGEX);
+		assert!(REGEX.replace("com.", "") == "com."); //matching this would cause to much false positive
+		assert!(REGEX.replace(".com.", "") == ".com.");
+		assert!(REGEX.replace("example.com.", "") == "");
+		assert!(REGEX.replace("ex_am-ple.com.", "") == "");
+		assert!(REGEX.replace(".example.com.", "") == ".");
+		assert!(REGEX.replace(":example.com.", "") == ":");
+		assert!(REGEX.replace("eiea.eiuuue.euu.", "") == "");
+		assert!(REGEX.replace("🐬.com.", "") == "");
+		assert!(REGEX.replace("👪.com.", "") == "");
+		assert!(REGEX.replace("♡.com.", "") == ""); //`♡` is a Math char
+		assert!(REGEX.replace("ä.com.", "") == "");
+		assert!(REGEX.replace("∫.com.", "") == ""); //is this a valid domain?
+		assert!(REGEX.replace(":.com.", "") == ":.com.");
 	}
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,49 @@
+use log::{Level, Record};
+use my_env_logger_style::env_logger::fmt::Formatter;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::{io, io::Write};
+
+static REGEX: Lazy<Regex> = Lazy::new(|| {
+	// https://ihateregex.io/expr/ip/
+	let regex_ipv4 = r"(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}";
+	// https://ihateregex.io/expr/ipv6/
+	let regex_ipv6 = r"(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+	// emoji: https://ihateregex.io/expr/emoji/
+	let regex_domain = r"(([\w\-]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))+\.){2,}";
+	Regex::new(&format! {"{regex_ipv4}|{regex_ipv6}|{regex_domain}"}).unwrap()
+});
+
+fn format(buf: &mut Formatter, record: &Record<'_>) -> io::Result<()> {
+	my_env_logger_style::format(buf, record)?;
+	Ok(())
+}
+
+pub(crate) fn init_logger() {
+	my_env_logger_style::get_set_max_module_len(20);
+	my_env_logger_style::set_arg_formatter(Box::new(
+		|buf: &mut Formatter, record: &Record<'_>| {
+			if let Some(mod_path) = record.module_path() {
+				if log::max_level() < Level::Debug && mod_path.starts_with("hickory") {
+					let message = format!("{}", record.args());
+					let message = REGEX.replace_all(&message, "RESTRAINED");
+					return writeln!(buf, "{}", message);
+				}
+			};
+			writeln!(buf, "{}", record.args())
+		}
+	))
+	.unwrap();
+	let mut logger = my_env_logger_style::builder();
+	logger.format(format).init();
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn regex() {
+		Lazy::force(&REGEX);
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate test;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 mod api;
+mod logger;
 mod parser;
 
 use anyhow::{bail, Context};
@@ -102,6 +103,8 @@ mod trie;
 
 mod blocklist;
 use blocklist::BlockList;
+
+use crate::logger::init_logger;
 
 #[derive(Debug, Clone)]
 struct Stats {
@@ -401,8 +404,7 @@ struct HttpsAndQuicConfig {
 }
 
 fn main() {
-	my_env_logger_style::get_set_max_module_len(20);
-	my_env_logger_style::just_log();
+	init_logger();
 	info!("🦀 {CARGO_PKG_NAME}  v{CARGO_PKG_VERSION} 🦀");
 	Lazy::force(&CONFIG_PATH);
 	Lazy::force(&LIST_DIR);


### PR DESCRIPTION
fix #15 partly.
Still leaks domain if top-level domains like `fritzbox.`.
Matching this would cause to much false positive.