### PR TITLE
Updated README.md due to DNSSEC issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ timeout_ms = 3000
 # optional
 [upstream.options]
 # optional (default = false )
-validate = true # use DNSSEC
+# Keep DNSSEC disabled due to Hickory DNS issue, see https://github.com/hickory-dns/hickory-dns/issues/2429
+# validate = true # use DNSSEC
 # see https://docs.rs/trust-dns-resolver/0.23.0/trust_dns_resolver/config/struct.ResolverOpts.html for all options
 
 [[upstream.name_servers]]

--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ protocol = "tls"
 tls_dns_name = "1dot1dot1dot1.cloudflare-dns.com"
 trust_nx_responses = false
 ```
+
+## DNSSEC Issues
+Due to an upstream issue of [hickory-dns](https://github.com/hickory-dns/hickory-dns/issues/2429), non DNSSEC sites will not be resolved if `validate = true`.
+Only DNSSEC capable sites will be resolved with this setting.
+To prevent this, set `validate = false` or omit the `[upstream.options]`.


### PR DESCRIPTION
Added the [DNSSEC issue](https://github.com/LuckyTurtleDev/crab-hole/issues/29) to the README.md.

Not sure if it would be better to additionally disable the `validate` option in the example config or not.