### PR TITLE
Updated ahash: 0.8.6 -> 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",


### PR DESCRIPTION
This fixes compilation issue for the benchmark.
ahash was updated from 0.8.6 to 0.8.11 in `Cargo.lock`

https://github.com/tkaitchuck/aHash/issues/227