### PR TITLE
Add H3 downstream option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ dns_hostname = "dns.example.com"
 # optional (default = 3000)
 timeout_ms = 3000
 
+[[downstream]]
+protocol = "h3"
+listen = "127.0.0.1"
+port = 8443
+certificate = "dns.example.com.crt"
+key = "dns.example.com.key"
+dns_hostname = "dns.example.com"
+# optional (default = 3000)
+timeout_ms = 3000
+
 # optional
 [upstream.options]
 # optional (default = false)

--- a/example-config.toml
+++ b/example-config.toml
@@ -56,6 +56,16 @@ dns_hostname = "dns.example.com"
 # optional (default = 3000)
 timeout_ms = 3000
 
+[[downstream]]
+protocol = "h3"
+listen = "127.0.0.1"
+port = 8443
+certificate = "dns.example.com.crt"
+key = "dns.example.com.key"
+dns_hostname = "dns.example.com"
+# optional (default = 3000)
+timeout_ms = 3000
+
 # optional
 [upstream.options]
 # optional (default = false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,20 @@ fn load_cert_and_key(
 	Ok((certificates, key))
 }
 
+impl TlsConfig {
+	#[inline(always)]
+	fn load_cert_and_key(&self) -> anyhow::Result<(Vec<Certificate>, PrivateKey)> {
+		load_cert_and_key(&self.certificate, &self.key)
+	}
+}
+
+impl HttpsAndQuicConfig {
+	#[inline(always)]
+	fn load_cert_and_key(&self) -> anyhow::Result<(Vec<Certificate>, PrivateKey)> {
+		load_cert_and_key(&self.certificate, &self.key)
+	}
+}
+
 /// Load a text file from url and cache it.
 /// If restore_from_cache is true, only the cache is used.
 /// The first return value is the file content.
@@ -354,9 +368,9 @@ async fn async_main(config: Config) {
 				server.register_socket(udp_socket);
 			},
 			DownstreamConfig::Tls(downstream) => {
-				let cert_and_key =
-					load_cert_and_key(&downstream.certificate, &downstream.key)
-						.expect("failed to load certificate or private key");
+				let cert_and_key = downstream
+					.load_cert_and_key()
+					.expect("failed to load certificate or private key");
 				let socket_addr = format!("{}:{}", downstream.listen, downstream.port);
 				let tcp_listener = TcpListener::bind(&socket_addr)
 					.await
@@ -371,9 +385,9 @@ async fn async_main(config: Config) {
 					.expect("failed to register tls downstream");
 			},
 			DownstreamConfig::Https(downstream) => {
-				let cert_and_key =
-					load_cert_and_key(&downstream.certificate, &downstream.key)
-						.expect("failed to load certificate or private key");
+				let cert_and_key = downstream
+					.load_cert_and_key()
+					.expect("failed to load certificate or private key");
 				let socket_addr = format!("{}:{}", downstream.listen, downstream.port);
 				let tcp_listener = TcpListener::bind(&socket_addr)
 					.await
@@ -386,16 +400,16 @@ async fn async_main(config: Config) {
 						cert_and_key,
 						downstream.dns_hostname
 					)
-					.expect("failed to register tls downstream");
+					.expect("failed to register https downstream");
 			},
 			DownstreamConfig::Quic(downstream) => {
-				let cert_and_key =
-					load_cert_and_key(&downstream.certificate, &downstream.key)
-						.expect("failed to load certificate or private key");
+				let cert_and_key = downstream
+					.load_cert_and_key()
+					.expect("failed to load certificate or private key");
 				let socket_addr = format!("{}:{}", downstream.listen, downstream.port);
 				let udp_socket = UdpSocket::bind(&socket_addr)
 					.await
-					.with_context(|| format!("failed to bind tcp socket {socket_addr}"))
+					.with_context(|| format!("failed to bind udp socket {socket_addr}"))
 					.unwrap_or_else(|err| panic!("{err:?}"));
 				server
 					.register_quic_listener(
@@ -404,7 +418,25 @@ async fn async_main(config: Config) {
 						cert_and_key,
 						downstream.dns_hostname
 					)
-					.expect("failed to register tls downstream");
+					.expect("failed to register quic downstream");
+			},
+			DownstreamConfig::H3(downstream) => {
+				let cert_and_key = downstream
+					.load_cert_and_key()
+					.expect("failed to load certificate or private key");
+				let socket_addr = format!("{}:{}", downstream.listen, downstream.port);
+				let udp_socket = UdpSocket::bind(&socket_addr)
+					.await
+					.with_context(|| format!("failed to bind udp socket {socket_addr}"))
+					.unwrap_or_else(|err| panic!("{err:?}"));
+				server
+					.register_h3_listener(
+						udp_socket,
+						Duration::from_millis(downstream.timeout_ms),
+						cert_and_key,
+						downstream.dns_hostname
+					)
+					.expect("failed to register h3 downstream");
 			}
 		}
 	}
@@ -460,7 +492,8 @@ enum DownstreamConfig {
 	Udp(UdpConfig),
 	Tls(TlsConfig),
 	Https(HttpsAndQuicConfig),
-	Quic(HttpsAndQuicConfig)
+	Quic(HttpsAndQuicConfig),
+	H3(HttpsAndQuicConfig)
 }
 
 fn default_timeout() -> u64 {


### PR DESCRIPTION
We even enabled the `dns-over-h3` feature already but apparently nobody ever added the downstream option.