### PR TITLE
add Unixlistener

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,11 @@ on:
 jobs:
 
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -29,7 +33,11 @@ jobs:
 
   test:
     needs: [check]
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update -y && sudo apt-get install -y knot-dnsutils

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,11 +33,7 @@ jobs:
 
   test:
     needs: [check]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update -y && sudo apt-get install -y knot-dnsutils

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,6 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util",
  "url",
 ]
 
@@ -2661,7 +2660,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -2653,13 +2654,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ time = { version = "0.3.44", features = ["macros"] } #poem-openapi have forgot t
 tokio = { version = "1.48", features = ["fs", "parking_lot", "rt-multi-thread", "macros", "net", "signal"] }
 toml = { package = "basic-toml", version = "0.1" }
 url = { version = "2.5.7", features = ["serde"] }
+tokio-util = { version = "0.7.18", features = ["rt"] }
 
 [dev-dependencies]
 indoc = "2.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ time = { version = "0.3.44", features = ["macros"] } #poem-openapi have forgot t
 tokio = { version = "1.48", features = ["fs", "parking_lot", "rt-multi-thread", "macros", "net", "signal"] }
 toml = { package = "basic-toml", version = "0.1" }
 url = { version = "2.5.7", features = ["serde"] }
-tokio-util = { version = "0.7.18", features = ["rt"] }
 
 [dev-dependencies]
 indoc = "2.0.6"

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ allow_list = ["file:///allowed.txt"]
 
 # optional
 [api]
-port = 8080
-listen = "127.0.0.1"
+listener = "127.0.0.1:8080"
+# to use unix sockets, start listener with `unix://` 
+#listener = "unix:///tmp/crab-hole.sock"
 # optional (default = false)
 show_doc = true # OpenAPI doc loads content from third party websites
 # optional

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ include_subdomains = true
 lists = [
 	"https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts",
 	"https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt",
-	"file:///blocked.txt"
+	#"file:///blocked.txt"
 ]
 
 # optional

--- a/config.toml
+++ b/config.toml
@@ -8,8 +8,7 @@ lists = [
 
 # optional
 [api]
-port = 8080
-listen = "127.0.0.1"
+listener = "/home/lukas/test.tmp"
 # optional (default = false)
 show_doc = true # OpenAPI doc loads content from third party websites
 # optional

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ lists = [
 
 # optional
 [api]
-listener = "/home/lukas/test.tmp"
+listener = "unix:///tmp/crab-hole.sock"
 # optional (default = false)
 show_doc = true # OpenAPI doc loads content from third party websites
 # optional

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,8 @@ lists = [
 
 # optional
 [api]
-listener = "unix:///tmp/crab-hole.sock"
+listener = "localhost:8080"
+#listener = "unix:///tmp/crab-hole.sock"
 # optional (default = false)
 show_doc = true # OpenAPI doc loads content from third party websites
 # optional

--- a/example-config.toml
+++ b/example-config.toml
@@ -10,8 +10,7 @@ allow_list = ["file:///allowed.txt"]
 
 # optional
 [api]
-port = 8080
-listen = "127.0.0.1"
+listener = "127.0.0.1:8080"
 # optional (default = false)
 show_doc = true # OpenAPI doc loads content from third party websites
 # optional

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,6 +2,7 @@ use crate::{
 	blocklist::{BlockList, FailedList, ListType, QueryInfo},
 	CARGO_PKG_NAME, CARGO_PKG_VERSION
 };
+use anyhow::Context;
 use log::info;
 use poem::{
 	http::StatusCode,
@@ -230,14 +231,14 @@ pub(crate) async fn init(
 			if path.exists() {
 				// enusre that the file is really an unix socket and we do not delte something important
 				let file = std::fs::File::open(path).unwrap();
-				if file.metadata().unwrap().file_type().is_socket() {
-					remove_file(&path).await.unwrap();
+				if file.metadata().with_context(|| format!("failed to open file {path:?}"))?.file_type().is_socket() {
+					remove_file(&path).await.with_context(|| format!("failed to remove existing socket {path:?}"))?;
 				}
 			}
 			Server::new(UnixListener::bind(listener))
 				.run(server)
 				.await?;
-			//todo remove file
+			//todo remove file at drop
 		} else {
 			Server::new(TcpListener::bind(config.listener))
 				.run(server)

--- a/src/api.rs
+++ b/src/api.rs
@@ -15,11 +15,10 @@ use poem_openapi::{
 use serde::Deserialize;
 use std::{
 	collections::HashMap,
-	path::Path,
+	path::{Path, PathBuf},
 	sync::{atomic::Ordering, Arc}
 };
 use time::OffsetDateTime;
-use tokio::fs::remove_file;
 
 #[derive(Debug, Deserialize, Object)]
 #[serde(deny_unknown_fields)]
@@ -227,28 +226,31 @@ pub(crate) async fn init(
 			#[cfg(unix)]
 			{
 				use poem::listener::UnixListener;
-				use std::os::unix::fs::FileTypeExt;
+				use std::fs::remove_file;
 
-				// Old sockets get left behind, so cleanup
-				let path = Path::new(listener);
-				if path.exists() {
-					// enusre that the file is really an unix socket and we do not delte something important
-					let file = std::fs::File::open(path).unwrap();
-					if file
-						.metadata()
-						.with_context(|| format!("failed to open file {path:?}"))?
-						.file_type()
-						.is_socket()
-					{
-						remove_file(&path).await.with_context(|| {
-							format!("failed to remove existing socket {path:?}")
-						})?;
+				/// Delete the given file on drop
+				struct FileDeleter(PathBuf);
+				impl Drop for FileDeleter {
+					fn drop(&mut self) {
+						if let Err(err) = remove_file(&self.0).with_context(|| {
+							format!("failed to remove file {:?}", self.0)
+						}) {
+							eprintln!("{err:?}");
+						}
 					}
 				}
+
+				let path = Path::new(listener);
+				// If socket not exist at start, we want to delte it after existing the program.
+				// If it already exist it was probally created by a service like systemd so we wan to keep it then.
+				let _delete_file = if path.exists() {
+					None
+				} else {
+					Some(FileDeleter(path.to_owned()))
+				};
 				Server::new(UnixListener::bind(listener))
 					.run(server)
 					.await?;
-				//todo remove file at drop
 			}
 		} else {
 			Server::new(TcpListener::bind(config.listener))

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@ use crate::{
 	CARGO_PKG_NAME, CARGO_PKG_VERSION
 };
 use anyhow::Context;
-use log::info;
+use log::{error, info};
 use poem::{http::StatusCode, listener::TcpListener, Route, Server};
 use poem_openapi::{
 	auth::ApiKey,
@@ -236,7 +236,7 @@ pub(crate) async fn init(
 						if let Err(err) = remove_file(&self.0).with_context(|| {
 							format!("failed to remove file {:?}", self.0)
 						}) {
-							eprintln!("{err:?}");
+							error!("{err:?}");
 						}
 					}
 				}

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,6 @@ use poem_openapi::{
 use serde::Deserialize;
 use std::{
 	collections::HashMap,
-	os::unix::fs::FileTypeExt,
 	path::Path,
 	sync::{atomic::Ordering, Arc}
 };
@@ -225,20 +224,28 @@ pub(crate) async fn init(
 		};
 		info!("start api/web server at {:?}", config.listener);
 		if let Some(listener) = config.listener.strip_prefix("unix://") {
-			// Old sockets get left behind, so cleanup
-			let path = Path::new(listener);
-			if path.exists() {
-				// enusre that the file is really an unix socket and we do not delte something important
-				let file = std::fs::File::open(path).unwrap();
-				if file
-					.metadata()
-					.with_context(|| format!("failed to open file {path:?}"))?
-					.file_type()
-					.is_socket()
-				{
-					remove_file(&path).await.with_context(|| {
-						format!("failed to remove existing socket {path:?}")
-					})?;
+			#[cfg(not(unix))]
+			{
+				anyhow::bail!("UnixListener is only supported on unix systems");
+			}
+			#[cfg(unix)]
+			{
+				use std::os::unix::fs::FileTypeExt;
+				// Old sockets get left behind, so cleanup
+				let path = Path::new(listener);
+				if path.exists() {
+					// enusre that the file is really an unix socket and we do not delte something important
+					let file = std::fs::File::open(path).unwrap();
+					if file
+						.metadata()
+						.with_context(|| format!("failed to open file {path:?}"))?
+						.file_type()
+						.is_socket()
+					{
+						remove_file(&path).await.with_context(|| {
+							format!("failed to remove existing socket {path:?}")
+						})?;
+					}
 				}
 			}
 			Server::new(UnixListener::bind(listener))

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,10 +23,10 @@ use time::OffsetDateTime;
 #[derive(Debug, Deserialize, Object)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
-	listener: String,
+	pub listener: String,
 	#[serde(default)]
-	show_doc: bool,
-	admin_key: Option<String>
+	pub show_doc: bool,
+	pub admin_key: Option<String>
 }
 
 #[derive(Debug, Object)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -222,7 +222,7 @@ pub(crate) async fn init(
 		if let Some(listener) = config.listener.strip_prefix("unix://") {
 			#[cfg(not(unix))]
 			{
-				anyhow::bail!("UnixListener is only supported on unix systems");
+				anyhow::bail!("unix sockets is only supported on unix systems");
 			}
 			#[cfg(unix)]
 			{

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use log::info;
 use poem::{
 	http::StatusCode,
-	listener::{self, TcpListener, UnixListener},
+	listener::{TcpListener, UnixListener},
 	Route, Server
 };
 use poem_openapi::{
@@ -19,8 +19,7 @@ use poem_openapi::{
 use serde::Deserialize;
 use std::{
 	collections::HashMap,
-	fs::FileType,
-	os::{self, unix::fs::FileTypeExt},
+	os::unix::fs::FileTypeExt,
 	path::Path,
 	sync::{atomic::Ordering, Arc}
 };

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,11 @@ use crate::{
 	CARGO_PKG_NAME, CARGO_PKG_VERSION
 };
 use log::info;
-use poem::{http::StatusCode, listener::TcpListener, Route, Server};
+use poem::{
+	http::StatusCode,
+	listener::{self, TcpListener, UnixListener},
+	Route, Server
+};
 use poem_openapi::{
 	auth::ApiKey,
 	param::Query,
@@ -14,15 +18,18 @@ use poem_openapi::{
 use serde::Deserialize;
 use std::{
 	collections::HashMap,
+	fs::FileType,
+	os::{self, unix::fs::FileTypeExt},
+	path::Path,
 	sync::{atomic::Ordering, Arc}
 };
 use time::OffsetDateTime;
+use tokio::fs::remove_file;
 
 #[derive(Debug, Deserialize, Object)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
-	port: u16,
-	listen: String,
+	listener: String,
 	#[serde(default)]
 	show_doc: bool,
 	admin_key: Option<String>
@@ -196,7 +203,6 @@ pub(crate) async fn init(
 	blocklist: Arc<BlockList>
 ) -> anyhow::Result<()> {
 	if let Some(config) = config {
-		let address = format!("{}:{}", config.listen, config.port);
 		let api_data = Api {
 			blocklist,
 			doc_enable: config.show_doc,
@@ -205,7 +211,7 @@ pub(crate) async fn init(
 		};
 		let api_service =
 			OpenApiService::new(api_data, CARGO_PKG_NAME, CARGO_PKG_VERSION)
-				.server(&address);
+				.server(&config.listener);
 		let doc = if config.show_doc {
 			Some(api_service.redoc())
 		} else {
@@ -217,8 +223,26 @@ pub(crate) async fn init(
 		} else {
 			server
 		};
-		info!("start api/web server at {address:?}");
-		Server::new(TcpListener::bind(address)).run(server).await?;
+		info!("start api/web server at {:?}", config.listener);
+		if let Some(listener) = config.listener.strip_prefix("unix://") {
+			// Old sockets get left behind, so cleanup
+			let path = Path::new(listener);
+			if path.exists() {
+				// enusre that the file is really an unix socket and we do not delte something important
+				let file = std::fs::File::open(path).unwrap();
+				if file.metadata().unwrap().file_type().is_socket() {
+					remove_file(&path).await.unwrap();
+				}
+			}
+			Server::new(UnixListener::bind(listener))
+				.run(server)
+				.await?;
+			//todo remove file
+		} else {
+			Server::new(TcpListener::bind(config.listener))
+				.run(server)
+				.await?;
+		}
 	}
 	Ok(())
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -242,8 +242,8 @@ pub(crate) async fn init(
 				}
 
 				let path = Path::new(listener);
-				// If socket not exist at start, we want to delte it after existing the program.
-				// If it already exist it was probally created by a service like systemd so we wan to keep it then.
+				// If the socket doesn't exist yet, we want to delete it after exiting the program.
+				// If it already existed, it was probally created by a service like systemd, so we want to keep it.
 				let delete_file = if path.exists() {
 					None
 				} else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,6 +19,7 @@ use std::{
 	sync::{atomic::Ordering, Arc}
 };
 use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Deserialize, Object)]
 #[serde(deny_unknown_fields)]
@@ -194,7 +195,8 @@ impl Api {
 pub(crate) async fn init(
 	config: Option<Config>,
 	stats: crate::Stats,
-	blocklist: Arc<BlockList>
+	blocklist: Arc<BlockList>,
+	shutdown: CancellationToken
 ) -> anyhow::Result<()> {
 	if let Some(config) = config {
 		let api_data = Api {
@@ -249,9 +251,12 @@ pub(crate) async fn init(
 				} else {
 					Some(FileDeleter(path.to_owned()))
 				};
-				Server::new(UnixListener::bind(listener))
-					.run(server)
-					.await?;
+				tokio::select! {
+					res = Server::new(UnixListener::bind(listener))
+					.run(server) => {res?},
+					// continue if we recieve a shutdown signal
+					_ = shutdown.cancelled() => {}
+				};
 				drop(delete_file);
 			}
 		} else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,6 @@ use std::{
 	sync::{atomic::Ordering, Arc}
 };
 use time::OffsetDateTime;
-use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Deserialize, Object)]
 #[serde(deny_unknown_fields)]
@@ -195,8 +194,7 @@ impl Api {
 pub(crate) async fn init(
 	config: Option<Config>,
 	stats: crate::Stats,
-	blocklist: Arc<BlockList>,
-	shutdown: CancellationToken
+	blocklist: Arc<BlockList>
 ) -> anyhow::Result<()> {
 	if let Some(config) = config {
 		let api_data = Api {
@@ -251,12 +249,9 @@ pub(crate) async fn init(
 				} else {
 					Some(FileDeleter(path.to_owned()))
 				};
-				tokio::select! {
-					res = Server::new(UnixListener::bind(listener))
-					.run(server) => {res?},
-					// continue if we recieve a shutdown signal
-					_ = shutdown.cancelled() => {}
-				};
+				Server::new(UnixListener::bind(listener))
+					.run(server)
+					.await?;
 				drop(delete_file);
 			}
 		} else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -232,6 +232,7 @@ pub(crate) async fn init(
 				struct FileDeleter(PathBuf);
 				impl Drop for FileDeleter {
 					fn drop(&mut self) {
+						info!("delete socket: {:?}", self.0);
 						if let Err(err) = remove_file(&self.0).with_context(|| {
 							format!("failed to remove file {:?}", self.0)
 						}) {
@@ -243,7 +244,7 @@ pub(crate) async fn init(
 				let path = Path::new(listener);
 				// If socket not exist at start, we want to delte it after existing the program.
 				// If it already exist it was probally created by a service like systemd so we wan to keep it then.
-				let _delete_file = if path.exists() {
+				let delete_file = if path.exists() {
 					None
 				} else {
 					Some(FileDeleter(path.to_owned()))
@@ -251,6 +252,7 @@ pub(crate) async fn init(
 				Server::new(UnixListener::bind(listener))
 					.run(server)
 					.await?;
+				drop(delete_file);
 			}
 		} else {
 			Server::new(TcpListener::bind(config.listener))

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,11 +4,7 @@ use crate::{
 };
 use anyhow::Context;
 use log::info;
-use poem::{
-	http::StatusCode,
-	listener::{TcpListener, UnixListener},
-	Route, Server
-};
+use poem::{http::StatusCode, listener::TcpListener, Route, Server};
 use poem_openapi::{
 	auth::ApiKey,
 	param::Query,
@@ -230,7 +226,9 @@ pub(crate) async fn init(
 			}
 			#[cfg(unix)]
 			{
+				use poem::listener::UnixListener;
 				use std::os::unix::fs::FileTypeExt;
+
 				// Old sockets get left behind, so cleanup
 				let path = Path::new(listener);
 				if path.exists() {
@@ -247,11 +245,11 @@ pub(crate) async fn init(
 						})?;
 					}
 				}
+				Server::new(UnixListener::bind(listener))
+					.run(server)
+					.await?;
+				//todo remove file at drop
 			}
-			Server::new(UnixListener::bind(listener))
-				.run(server)
-				.await?;
-			//todo remove file at drop
 		} else {
 			Server::new(TcpListener::bind(config.listener))
 				.run(server)

--- a/src/api.rs
+++ b/src/api.rs
@@ -231,8 +231,15 @@ pub(crate) async fn init(
 			if path.exists() {
 				// enusre that the file is really an unix socket and we do not delte something important
 				let file = std::fs::File::open(path).unwrap();
-				if file.metadata().with_context(|| format!("failed to open file {path:?}"))?.file_type().is_socket() {
-					remove_file(&path).await.with_context(|| format!("failed to remove existing socket {path:?}"))?;
+				if file
+					.metadata()
+					.with_context(|| format!("failed to open file {path:?}"))?
+					.file_type()
+					.is_socket()
+				{
+					remove_file(&path).await.with_context(|| {
+						format!("failed to remove existing socket {path:?}")
+					})?;
 				}
 			}
 			Server::new(UnixListener::bind(listener))

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,18 +453,18 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 	info!("🚀 start dns server");
 
 	select! {
-		 res = async {
+		res = async {
 			server
 				.block_until_done()
 				.await
 				.with_context(|| "failed to start dns server")
 		} => {res}
-		 res = async {
+		res = async {
 			api::init(config.api, stats, blocklist)
 				.await
 				.with_context(|| "failed to start api/web server")
 		}, if config.api.is_some() => {res} //on none init return directly
-		 res  = async {
+		res = async {
 			signal::ctrl_c().await.context("failed to listen for signal")
 		} => {res}
 	}?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,7 +465,7 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 			api::init(config.api, stats, blocklist, shutdown.clone())
 				.await
 				.with_context(|| "failed to start api/web server")
-		} => {res}
+		}, if config.api.is_some() => {res} //on none init return directly
 		 res  = async {
 			signal::ctrl_c().await.context("failed to listen for signal")
 		} => {res}

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ async fn get_file(
 }
 
 #[tokio::main]
-async fn async_main(config: Config) -> anyhow::Result<()>{
+async fn async_main(config: Config) -> anyhow::Result<()> {
 	let stats = Stats::default();
 	let handler = Handler::new(&config, stats.clone()).await;
 	let blocklist = handler.blocklist.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,7 +571,7 @@ enum Commands {
 	ValidateLists
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> ExitCode {
 	init_logger();
 	info!("🦀 {CARGO_PKG_NAME}  v{CARGO_PKG_VERSION} 🦀");
 	Lazy::force(&CONFIG_PATH);
@@ -602,18 +602,22 @@ fn main() -> anyhow::Result<()> {
 
 	match cli.command {
 		Some(command) => match command {
-			Commands::ValidateConfig => info!("Config is valid"),
+			Commands::ValidateConfig => {
+				info!("Config is valid");
+				ExitCode::SUCCESS
+			},
 			Commands::ValidateLists => {
 				if !async_validate_lists(config) {
-					bail!("Config validation failed!");
+					error!("Config validation failed!");
+					ExitCode::FAILURE
 				} else {
 					info!("All lists are valid");
+					ExitCode::SUCCESS
 				}
 			},
 		},
-		None => async_main(config)?
-	};
-	Ok(())
+		None => async_main(config)
+	}
 }
 
 fn load_config() -> Result<Config, anyhow::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ use tokio::{
 	select, signal,
 	time::sleep
 };
-use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use clap::{Parser, Subcommand};
@@ -452,7 +451,6 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 		}
 	});
 	info!("🚀 start dns server");
-	let shutdown = CancellationToken::new();
 
 	select! {
 		 res = async {
@@ -462,7 +460,7 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 				.with_context(|| "failed to start dns server")
 		} => {res}
 		 res = async {
-			api::init(config.api, stats, blocklist, shutdown.clone())
+			api::init(config.api, stats, blocklist)
 				.await
 				.with_context(|| "failed to start api/web server")
 		}, if config.api.is_some() => {res} //on none init return directly

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use std::{
 	io::BufReader,
 	iter,
 	path::{Path, PathBuf},
+	process::ExitCode,
 	sync::{
 		atomic::{AtomicU64, Ordering},
 		Arc
@@ -349,7 +350,7 @@ async fn get_file(
 }
 
 #[tokio::main]
-async fn async_main(config: Config) -> anyhow::Result<()> {
+async fn async_main(config: Config) -> ExitCode {
 	let stats = Stats::default();
 	let handler = Handler::new(&config, stats.clone()).await;
 	let blocklist = handler.blocklist.clone();
@@ -450,7 +451,7 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 		}
 	});
 	info!("🚀 start dns server");
-	try_join!(
+	let res = try_join!(
 		async {
 			server
 				.block_until_done()
@@ -462,8 +463,17 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
 				.await
 				.with_context(|| "failed to start api/web server")
 		}
-	)?;
-	Ok(())
+	);
+	match res {
+		Ok(_) => {
+			info!("🛑 stop dns server");
+			ExitCode::SUCCESS
+		},
+		Err(err) => {
+			error!("🛑 dns server produced an irrecoverable error: {err}");
+			ExitCode::FAILURE
+		}
+	}
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,10 @@ use time::OffsetDateTime;
 use tokio::{
 	fs::{read_to_string, write},
 	net::{TcpListener, UdpSocket},
-	time::sleep,
-	try_join
+	select, signal,
+	time::sleep
 };
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use clap::{Parser, Subcommand};
@@ -350,7 +351,7 @@ async fn get_file(
 }
 
 #[tokio::main]
-async fn async_main(config: Config) -> ExitCode {
+async fn async_main(config: Config) -> anyhow::Result<()> {
 	let stats = Stats::default();
 	let handler = Handler::new(&config, stats.clone()).await;
 	let blocklist = handler.blocklist.clone();
@@ -451,29 +452,25 @@ async fn async_main(config: Config) -> ExitCode {
 		}
 	});
 	info!("🚀 start dns server");
-	let res = try_join!(
-		async {
+	let shutdown = CancellationToken::new();
+
+	select! {
+		 res = async {
 			server
 				.block_until_done()
 				.await
 				.with_context(|| "failed to start dns server")
-		},
-		async {
-			api::init(config.api, stats, blocklist)
+		} => {res}
+		 res = async {
+			api::init(config.api, stats, blocklist, shutdown.clone())
 				.await
 				.with_context(|| "failed to start api/web server")
-		}
-	);
-	match res {
-		Ok(_) => {
-			info!("🛑 stop dns server");
-			ExitCode::SUCCESS
-		},
-		Err(err) => {
-			error!("🛑 dns server produced an irrecoverable error: {err}");
-			ExitCode::FAILURE
-		}
-	}
+		} => {res}
+		 res  = async {
+			signal::ctrl_c().await.context("failed to listen for signal")
+		} => {res}
+	}?;
+	Ok(())
 }
 
 #[derive(Debug, Deserialize)]
@@ -616,7 +613,16 @@ fn main() -> ExitCode {
 				}
 			},
 		},
-		None => async_main(config)
+		None => match async_main(config) {
+			Ok(_) => {
+				info!("🛑 stop dns server");
+				ExitCode::SUCCESS
+			},
+			Err(err) => {
+				error!("🛑 crab-hole produced an irrecoverable error:\n{err:?}");
+				ExitCode::FAILURE
+			}
+		}
 	}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,8 +755,15 @@ mod tests {
 	#[ignore]
 	fn run() {
 		let config = include_bytes!("../config.toml");
-		let config: super::Config = toml::from_slice(config).unwrap();
-		let _ = thread::spawn(|| async_main(config));
+		let mut config: super::Config = toml::from_slice(config).unwrap();
+		// we can not use unix socket here.
+		// Since the thread will not be shut down gracefull and the socket would remain.
+		if let Some(api) = config.api.as_mut() {
+			if api.listener.starts_with("unix://") {
+				api.listener = "localhost:8080".to_owned()
+			}
+		}
+		thread::spawn(|| async_main(config));
 		let duration = Duration::from_secs(6);
 		sleep(duration);
 		assert!(Command::new("kdig")

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ async fn get_file(
 }
 
 #[tokio::main]
-async fn async_main(config: Config) {
+async fn async_main(config: Config) -> anyhow::Result<()>{
 	let stats = Stats::default();
 	let handler = Handler::new(&config, stats.clone()).await;
 	let blocklist = handler.blocklist.clone();
@@ -450,7 +450,7 @@ async fn async_main(config: Config) {
 		}
 	});
 	info!("🚀 start dns server");
-	let res = try_join!(
+	try_join!(
 		async {
 			server
 				.block_until_done()
@@ -462,8 +462,8 @@ async fn async_main(config: Config) {
 				.await
 				.with_context(|| "failed to start api/web server")
 		}
-	);
-	res.unwrap();
+	)?;
+	Ok(())
 }
 
 #[derive(Debug, Deserialize)]
@@ -561,7 +561,7 @@ enum Commands {
 	ValidateLists
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
 	init_logger();
 	info!("🦀 {CARGO_PKG_NAME}  v{CARGO_PKG_VERSION} 🦀");
 	Lazy::force(&CONFIG_PATH);
@@ -595,15 +595,15 @@ fn main() {
 			Commands::ValidateConfig => info!("Config is valid"),
 			Commands::ValidateLists => {
 				if !async_validate_lists(config) {
-					error!("Config validation failed!");
-					std::process::exit(1);
+					bail!("Config validation failed!");
 				} else {
 					info!("All lists are valid");
 				}
 			},
 		},
-		None => async_main(config)
-	}
+		None => async_main(config)?
+	};
+	Ok(())
 }
 
 fn load_config() -> Result<Config, anyhow::Error> {


### PR DESCRIPTION
replace: #51 
fix: #49

Change config:
move `port` and `listen` to a single new `listener` .
If `listener` start with with the prefix `unix://`, the listener will be interpreted as unix listener.